### PR TITLE
Add space platform listing UI

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,7 @@
+std = "lua51"
+read_globals = {
+  "script",
+  "game",
+  "defines",
+  "data"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-Placeholder
+# Space Platform Organizer UI
+
+This Factorio mod adds a simple UI listing all space platforms currently available to your force.
+
+Press the **Open space platform list** keybind (unassigned by default) to toggle the window.
+The window shows platform names as buttons in a scrollable list; clicking a button opens the selected platform view.

--- a/control.lua
+++ b/control.lua
@@ -1,0 +1,72 @@
+local UI_NAME = "space-platform-org-ui"
+local BUTTON_PREFIX = "sp-ui-btn-"
+
+local function build_platform_ui(player)
+  local frame = player.gui.screen.add{
+    type = "frame",
+    name = UI_NAME,
+    caption = {"space-platform-org-ui-title"},
+    direction = "vertical"
+  }
+  frame.auto_center = true
+
+  local scroll = frame.add{
+    type = "scroll-pane",
+    name = "platform_scroll"
+  }
+  scroll.style.maximal_height = 400
+  scroll.style.minimal_width = 250
+  scroll.style.vertically_stretchable = true
+  scroll.style.horizontally_stretchable = true
+
+  local platforms = (player.force and player.force.space_platforms) or {}
+  for _, platform in pairs(platforms) do
+    local caption = platform.backer_name or platform.name or ("Platform " .. (platform.index or _))
+    scroll.add{
+      type = "button",
+      name = BUTTON_PREFIX .. tostring(platform.index or _),
+      caption = caption
+    }
+  end
+end
+
+local function toggle_platform_ui(player)
+  local existing = player.gui.screen[UI_NAME]
+  if existing and existing.valid then
+    existing.destroy()
+  else
+    build_platform_ui(player)
+  end
+end
+
+script.on_event("space-platform-org-ui-toggle", function(event)
+  local player = game.get_player(event.player_index)
+  if player then
+    toggle_platform_ui(player)
+  end
+end)
+
+script.on_event(defines.events.on_gui_click, function(event)
+  local element = event.element
+  local player = game.get_player(event.player_index)
+  if not (element and element.valid and player) then return end
+
+  if string.sub(element.name, 1, #BUTTON_PREFIX) == BUTTON_PREFIX then
+    local id = tonumber(string.sub(element.name, #BUTTON_PREFIX + 1))
+    if id and player.force and player.force.space_platforms then
+      local platform = player.force.space_platforms[id]
+      if platform then
+        player.opened = platform
+        local ui = player.gui.screen[UI_NAME]
+        if ui and ui.valid then ui.destroy() end
+      end
+    end
+  end
+end)
+
+script.on_event(defines.events.on_gui_closed, function(event)
+  local element = event.element
+  if element and element.valid and element.name == UI_NAME then
+    element.destroy()
+  end
+end)

--- a/data.lua
+++ b/data.lua
@@ -1,0 +1,8 @@
+data:extend({
+  {
+    type = "custom-input",
+    name = "space-platform-org-ui-toggle",
+    key_sequence = "",
+    consuming = "none"
+  }
+})

--- a/info.json
+++ b/info.json
@@ -1,0 +1,9 @@
+{
+  "name": "space-platform-org-ui",
+  "version": "0.1.0",
+  "title": "Space Platform Organizer UI",
+  "author": "OpenAI",
+  "description": "Simple UI listing all space platforms with quick access.",
+  "factorio_version": "2.0",
+  "dependencies": ["base >= 2.0"]
+}

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -1,0 +1,5 @@
+[controls]
+space-platform-org-ui-toggle=Open space platform list
+
+[gui]
+space-platform-org-ui-title=Space Platforms


### PR DESCRIPTION
## Summary
- add keybind and UI to display all space platforms with buttons
- open selected platform view on button click
- document mod and provide locale entries

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68abadbcb3c88333b7cf87b395a25ee4