### PR TITLE
Gracefully handle missing space_platforms property

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -3,3 +3,4 @@ space-platform-org-ui-toggle=Open space platform list
 
 [gui]
 space-platform-org-ui-title=Space Platforms
+space-platform-org-ui-no-platforms=Did not find any space platforms, do you have any?


### PR DESCRIPTION
## Summary
- avoid runtime error when `LuaForce.space_platforms` is unavailable
- add helper to safely fetch platforms by scanning `game.surfaces`
- inform players when no space platforms are found

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68abcc5d0ac88333abe55fafea9f39d1