### PR TITLE
Use surface name for space platform captions

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -47,7 +47,7 @@ local function build_platform_ui(player)
   scroll.style.horizontally_stretchable = true
 
   for _, platform in pairs(platforms) do
-    local caption = platform.backer_name or platform.name or ("Platform " .. (platform.index or _))
+    local caption = (platform.surface and platform.surface.name) or ("Platform " .. (platform.index or _))
     scroll.add{
       type = "button",
       name = BUTTON_PREFIX .. tostring(platform.index or _),


### PR DESCRIPTION
## Summary
- Use the platform's surface name for UI captions instead of `backer_name`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd307d14c83339039081a5481a6ab