### PR TITLE
Discover platforms via surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This Factorio mod adds a simple UI listing all space platforms currently availab
 
 Press the **Open space platform list** keybind (unassigned by default) to toggle the window.
 The window shows platform names as buttons in a scrollable list; clicking a button opens the selected platform view.
+For debugging, the mod now prints the accessible properties of every surface to help identify which surfaces represent space platforms.


### PR DESCRIPTION
## Summary
- detect space platforms by inspecting `game.surfaces` instead of relying on missing `game.space_platforms`
- print available properties for each surface to the player for easier platform identification
- document debug surface property output in the README

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68abe0ad53a483339eb218f769b268a8