### PR TITLE
Expand surface debug output to show key/value pairs

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -30,7 +30,10 @@ local function print_surface_properties(player)
         end
       end
     end
-    player.print("Surface '" .. surface.name .. "' properties: " .. table.concat(props, ", "))
+    player.print("Surface '" .. surface.name .. "' properties (" .. #props .. "):")
+    for _, prop in ipairs(props) do
+      player.print("  " .. prop)
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- Print each surface property as a key/value pair when toggling the UI

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68abe91ffce0833397fa953c057ace70