### PR TITLE
Add auto version bump GitHub Actions workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,34 @@
+name: Bump version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  bump:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Bump patch version
+        id: bump
+        run: |
+          version=$(jq -r '.version' info.json)
+          IFS='.' read -r major minor patch <<< "$version"
+          patch=$((patch + 1))
+          new_version="$major.$minor.$patch"
+          jq ".version = \"$new_version\"" info.json > tmp && mv tmp info.json
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+      - name: Commit and push
+        run: |
+          git commit -am "Bump version to ${NEW_VERSION}"
+          git push
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}


### PR DESCRIPTION
## Summary
- add CI workflow to increment `info.json` patch version on pushes to main

## Testing
- `luacheck .`


------
https://chatgpt.com/codex/tasks/task_e_68abf0454a48833396c57d84fbde96b6