### PR TITLE
Handle nil global table in UI debug output

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -30,6 +30,11 @@ end
 
 local function print_global_table(player)
   player.print("Contents of global table (platform/space/surface):")
+  if not global then
+    player.print("  Global table is nil (no entries yet)")
+    return
+  end
+
   local has_entries = false
   for k, v in pairs(global) do
     local key = tostring(k)


### PR DESCRIPTION
## Summary
- Avoid errors when printing global debug info by checking if the `global` table exists

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*
- `luac -p control.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf9f262ec8333b67a341c1f0a382f