### PR TITLE
Show platform names in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,3 @@ This Factorio mod adds a simple UI listing all space platforms currently availab
 
 Press the **Open space platform list** keybind (unassigned by default) to toggle the window.
 The window shows platform names as buttons in a scrollable list; clicking a button opens the selected platform view.
-For debugging, the mod now prints the accessible properties of every surface to help identify which surfaces represent space platforms.
-It also lists all available remote interfaces and their function names in the in-game chat and log whenever the hotkey is pressed.

--- a/control.lua
+++ b/control.lua
@@ -1,4 +1,4 @@
--- luacheck: globals remote serpent log
+-- luacheck: globals script defines
 
 local UI_NAME = "space-platform-org-ui"
 local BUTTON_PREFIX = "sp-ui-btn-"
@@ -6,91 +6,18 @@ local BUTTON_PREFIX = "sp-ui-btn-"
 local function get_space_platforms(force)
   if not (force and force.valid) then return nil end
   local platforms = {}
-  -- Derive platforms by inspecting available surfaces.
+  -- Derive platforms by inspecting available surfaces whose names start with 'platform-'.
   for _, surface in pairs(game.surfaces) do
-    local ok, platform = pcall(function() return surface.platform end)
-    if ok and platform and platform.valid and platform.force == force then
-      platforms[platform.index] = platform
+    local ok_name, surface_name = pcall(function() return surface.name end)
+    if ok_name and type(surface_name) == "string" and surface_name:find("^platform%-") then
+      local ok_platform, platform = pcall(function() return surface.platform end)
+      if ok_platform and platform and platform.valid and platform.force == force then
+        platforms[platform.index] = {platform = platform, surface_name = surface_name}
+      end
     end
   end
   if next(platforms) then return platforms end
   return nil
-end
-
-local function print_remote_interfaces(player)
-  for name, interface in pairs(remote.interfaces) do
-    player.print("Remote interface '" .. name .. "':")
-    for func_name, func in pairs(interface) do
-      if type(func) == "function" then
-        player.print("  " .. func_name)
-      end
-    end
-  end
-end
-
-local function print_platform_surfaces(player)
-  local function print_log(msg)
-    player.print(msg)
-    log(msg)
-  end
-
-  print_log("Surfaces starting with 'platform-':")
-  local found = false
-  for _, surface in pairs(game.surfaces) do
-    -- Safely fetch the surface name and ensure it matches our prefix.
-    local ok_name, surface_name = pcall(function() return surface.name end)
-    if ok_name and type(surface_name) == "string" and surface_name:find("^platform%-") then
-      found = true
-      print_log("  Surface: " .. surface_name)
-
-      -- Print whether the surface is valid.
-      local ok_valid, surface_valid = pcall(function() return surface.valid end)
-      if ok_valid then
-        print_log("    valid: " .. tostring(surface_valid))
-      else
-        print_log("    valid: [error]")
-      end
-
-      -- If there is a platform associated with the surface, inspect known fields.
-      local ok_platform, platform = pcall(function() return surface.platform end)
-      if ok_platform and platform then
-        print_log("    platform type: " .. type(platform))
-
-        local ok_pname, p_name = pcall(function() return platform.name end)
-        if ok_pname then
-          print_log("      name: " .. tostring(p_name))
-        else
-          print_log("      name: [error]")
-        end
-
-        local ok_pindex, p_index = pcall(function() return platform.index end)
-        if ok_pindex then
-          print_log("      index: " .. tostring(p_index))
-        else
-          print_log("      index: [error]")
-        end
-
-        local ok_pvalid, p_valid = pcall(function() return platform.valid end)
-        if ok_pvalid then
-          print_log("      valid: " .. tostring(p_valid))
-        else
-          print_log("      valid: [error]")
-        end
-
-        local ok_force, p_force = pcall(function() return platform.force end)
-        if ok_force and p_force then
-          local ok_force_name, force_name = pcall(function() return p_force.name end)
-          print_log("      force: " .. (ok_force_name and tostring(force_name) or "[error]"))
-        end
-      else
-        print_log("    platform: " .. (ok_platform and "nil" or "[error]"))
-      end
-    end
-  end
-
-  if not found then
-    print_log("  (none)")
-  end
 end
 
 local function build_platform_ui(player)
@@ -120,11 +47,12 @@ local function build_platform_ui(player)
   scroll.style.vertically_stretchable = true
   scroll.style.horizontally_stretchable = true
 
-  for _, platform in pairs(platforms) do
-    local caption = platform.name or ("Platform " .. (platform.index or _))
+  for _, data in pairs(platforms) do
+    local platform = data.platform
+    local caption = (platform and platform.name) or data.surface_name
     scroll.add{
       type = "button",
-      name = BUTTON_PREFIX .. tostring(platform.index or _),
+      name = BUTTON_PREFIX .. tostring(platform and platform.index),
       caption = caption
     }
   end
@@ -135,8 +63,6 @@ local function toggle_platform_ui(player)
   if existing and existing.valid then
     existing.destroy()
   else
-    print_remote_interfaces(player)
-    print_platform_surfaces(player)
     build_platform_ui(player)
   end
 end
@@ -157,7 +83,8 @@ script.on_event(defines.events.on_gui_click, function(event)
     local id = tonumber(string.sub(element.name, #BUTTON_PREFIX + 1))
     local platforms = get_space_platforms(player.force)
     if id and platforms then
-      local platform = platforms[id]
+      local entry = platforms[id]
+      local platform = entry and entry.platform
       if platform then
         player.opened = platform
         local ui = player.gui.screen[UI_NAME]


### PR DESCRIPTION
## Summary
- Display real space platform names in the organizer UI, falling back to surface names if missing
- Remove verbose debug logging and remote interface dumps
- Filter surfaces by `platform-` prefix and safely access `surface.platform`

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac02ed8ac48333bd55aab5ba1c2895