### PR TITLE
Use platform caption and open platform

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -32,8 +32,8 @@ local function collect_platform_surfaces()
       log(log_message)
       table.insert(platforms, {
         surface_name = surface_name,
-        caption = caption,
-        platform = ok_platform and platform or nil
+        platform = ok_platform and platform or nil,
+        caption = tostring(caption)
       })
     end
   end
@@ -71,7 +71,6 @@ local function build_platform_ui(player)
     scroll.add{
       type = "button",
       name = BUTTON_PREFIX .. entry.surface_name,
-      -- caption precomputed from platform or surface name
       caption = entry.caption,
       tags = { surface = entry.surface_name }
     }
@@ -105,7 +104,10 @@ script.on_event(defines.events.on_gui_click, function(event)
     if surface_name then
       local surface = game.surfaces[surface_name]
       if surface then
-        pcall(function() player.opened = surface end)
+        local platform = surface.platform
+        if platform then
+          pcall(function() player.opened = platform end)
+        end
         local ui = player.gui.screen[UI_NAME]
         if ui and ui.valid then ui.destroy() end
       end


### PR DESCRIPTION
## Summary
- include a caption for each surface entry using platform name when available
- build UI buttons with precomputed captions and unique surface-based names
- clicking a button opens the platform entity

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_68ac105154cc8333a5b126c2b614212e