### PR TITLE
Use safe accessor for global state

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -226,7 +226,6 @@ script.on_event(defines.events.on_gui_click, function(event)
   st.w = math.max(320, math.min(900, st.w + (delta_w or 0)))
   st.h = math.max(240, math.min(900, st.h + (delta_h or 0)))
   local g = get_global()
-  g.spui = g.spui or {}
   g.spui[player.index] = st
   local frame = player.gui.screen[UI_NAME]
   if frame and frame.valid then


### PR DESCRIPTION
## Summary
- Add `get_global()` helper for safe access to Factorio's global table
- Replace direct `global` reads/writes with `get_global()` usage in UI state and events

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68acd07c834483338b9aa5896314b7b3