### PR TITLE
Handle Factorio 2.0 style changes

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -222,11 +222,7 @@ local function build_platform_ui(player)
       b.style.top_padding    = 2
       b.style.bottom_padding = 2
       if i % 2 == 0 then
-        local gs = { base = { position = {0, 0}, corner_size = 8, tint = tan } }
-        b.style.default_graphical_set  = gs
-        b.style.hovered_graphical_set  = gs
-        b.style.clicked_graphical_set  = gs
-        b.style.disabled_graphical_set = gs
+        b.style.color = tan
       end
     end
   end


### PR DESCRIPTION
## Summary
- Use `color` style property for alternating platform buttons instead of removed `*_graphical_set` fields

## Testing
- `luacheck control.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_68ad67d79ba083339f70698387f170c9